### PR TITLE
Normalize GPT-5 Thinking model aliases and add quota entry

### DIFF
--- a/quota.json
+++ b/quota.json
@@ -1,0 +1,8 @@
+{
+  "gpt-5": {
+    "window": "3h"
+  },
+  "gpt-5-thinking": {
+    "window": "1w"
+  }
+}

--- a/src/chatgptQuotaModelMapper.js
+++ b/src/chatgptQuotaModelMapper.js
@@ -1,0 +1,27 @@
+const MODEL_ALIASES = {
+  'gpt-5.5-thinking': 'gpt-5-thinking',
+  'gpt-5-5-thinking': 'gpt-5-thinking',
+  'gpt-5-thinking-latest': 'gpt-5-thinking',
+  'gpt-5-thinking': 'gpt-5-thinking'
+};
+
+function mapQuotaModel(rawModel) {
+  const normalizedRawModel = typeof rawModel === 'string' ? rawModel.trim() : '';
+  const mappedModel = MODEL_ALIASES[normalizedRawModel] || normalizedRawModel;
+
+  if (typeof console !== 'undefined' && typeof console.debug === 'function') {
+    console.debug('[chatgpt-quota] model mapping', {
+      rawModel: normalizedRawModel,
+      mappedModel
+    });
+  }
+
+  return mappedModel;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = {
+    MODEL_ALIASES,
+    mapQuotaModel
+  };
+}

--- a/test/chatgptQuotaModelMapper.test.js
+++ b/test/chatgptQuotaModelMapper.test.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+const { mapQuotaModel } = require('../src/chatgptQuotaModelMapper');
+
+const thinkingAliases = [
+  'gpt-5.5-thinking',
+  'gpt-5-5-thinking',
+  'gpt-5-thinking-latest',
+  'gpt-5-thinking'
+];
+
+for (const model of thinkingAliases) {
+  assert.strictEqual(mapQuotaModel(model), 'gpt-5-thinking');
+}
+
+assert.strictEqual(mapQuotaModel('gpt-5'), 'gpt-5');
+assert.strictEqual(mapQuotaModel(' gpt-5.5-thinking '), 'gpt-5-thinking');
+
+console.log('chatgptQuotaModelMapper tests passed');


### PR DESCRIPTION
### Motivation
- Ensure the quota system recognizes the various model names users may send when selecting GPT‑5/GPT‑5.5 Thinking in the ChatGPT web UI.
- Provide a quota entry for the Thinking variant so its weekly window is enforced alongside GPT‑5's 3‑hour window.

### Description
- Add `quota.json` with entries for `gpt-5` (`"window": "3h"`) and `gpt-5-thinking` (`"window": "1w"`).
- Add `src/chatgptQuotaModelMapper.js` which maps aliases `gpt-5.5-thinking`, `gpt-5-5-thinking`, `gpt-5-thinking-latest`, and `gpt-5-thinking` to `gpt-5-thinking` and returns unmapped names unchanged.
- The mapper normalizes input with `trim()` and emits a debug log via `console.debug('[chatgpt-quota] model mapping', { rawModel, mappedModel })` to print both the raw and mapped model.
- Export `MODEL_ALIASES` and `mapQuotaModel` for reuse and testing.

### Testing
- Added `test/chatgptQuotaModelMapper.test.js` which asserts all Thinking aliases map to `gpt-5-thinking`, that `gpt-5` remains `gpt-5`, and that trimmed input is handled.
- Ran `node test/chatgptQuotaModelMapper.test.js` and the test completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a053670d978832c94902c8bca456011)